### PR TITLE
Specify max_chars not tokens

### DIFF
--- a/publang/search/embed.py
+++ b/publang/search/embed.py
@@ -12,22 +12,22 @@ from publang.utils.oai import get_openai_embedding
 def embed_pmc_articles(
     articles: Union[str, List[str]],
     model_name: str = "text-embedding-ada-002",
-    min_tokens: int = 30,
-    max_tokens: int = 4000,
+    min_chars: int = 30,
+    max_chars: int = 4000,
     num_workers: int = 1,
     **kwargs
 ) -> List[Dict[str, any]]:
     """Embed a PMC article using OpenAI's API.
-    Split the article into chunks of min_tokens to max_tokens,
+    Split the article into chunks of min_chars to max_chars,
     and embed each chunk.
     """
 
     if isinstance(articles, str):
         articles = [articles]
 
-    def _split_embed(article, model_name, min_tokens, max_tokens, **kwargs):
+    def _split_embed(article, model_name, min_chars, max_chars, **kwargs):
         split_doc = split_pmc_document(
-            article, min_tokens=min_tokens, max_tokens=max_tokens
+            article, min_chars=min_chars, max_chars=max_chars
         )
 
         if split_doc:
@@ -47,8 +47,8 @@ def embed_pmc_articles(
                 _split_embed,
                 article,
                 model_name,
-                min_tokens,
-                max_tokens,
+                min_chars,
+                max_chars,
                 **kwargs,
             )
             for article in articles

--- a/publang/tests/conftest.py
+++ b/publang/tests/conftest.py
@@ -24,7 +24,7 @@ def test_docs_body(test_docs):
     """ Returns first Body section for each tes paper"""
     sections = []
     for doc in test_docs:
-        for section in split_pmc_document(doc['text'], max_tokens=None):
+        for section in split_pmc_document(doc['text'], max_chars=None):
             if section.get('section_0', '') == 'Body':
                 sections.append(section['content'])
 

--- a/publang/tests/test_utils_split.py
+++ b/publang/tests/test_utils_split.py
@@ -3,14 +3,14 @@ from publang.utils.split import split_lines, split_markdown, _flatten_sections, 
 
 def test_split_lines():
     text = "This is a test.\nThis is only a test."
-    result = split_lines(text, max_tokens=20)
+    result = split_lines(text, max_chars=20)
     assert result == ["This is a test.", "\nThis is only a test."]
 
 
 def test_split_markdown():
     text = "# Header\nThis is a test.\n## Subheader\nThis is only a test."
     delimiters = ["# ", "## "]
-    result = split_markdown(text, delimiters, min_tokens=20, max_tokens=50)
+    result = split_markdown(text, delimiters, min_chars=20, max_chars=50)
     assert result == [(None, [(None, '# Header\nThis is a test.'), ('Subheader', '\n## Subheader\nThis is only a test.')])]
 
 
@@ -23,7 +23,7 @@ def test__flatten_sections():
 def test_split_pmc_document(test_docs):
     text = test_docs[0]['text']
     delimiters = ["# ", "## ", "###"]
-    result = split_pmc_document(text, delimiters, min_tokens=20, max_tokens=50)
+    result = split_pmc_document(text, delimiters, min_chars=20, max_chars=50)
     assert len(result) == 180
 
     # First section is author names

--- a/publang/utils/split.py
+++ b/publang/utils/split.py
@@ -3,10 +3,8 @@ from typing import List, Optional
 import warnings
 
 
-def split_lines(text: str, max_tokens: int = 100) -> List[str]:
-    """Join strings to form largest possible strings that are less than max_tokens.
-    
-    ## TODO: Define tokens as not just chars, and force split if a line is too long. 
+def split_lines(text: str, max_chars: int = 100) -> List[str]:
+    """Join strings to form largest possible strings that are less than max_chars
     """
 
     strings = text.splitlines()
@@ -18,7 +16,7 @@ def split_lines(text: str, max_tokens: int = 100) -> List[str]:
     for ix, string in enumerate(strings):
         if ix != 0:
             string = "\n" + string
-        if len(current_chunk) + len(string) + 1 <= max_tokens:
+        if len(current_chunk) + len(string) + 1 <= max_chars:
             current_chunk += string
         else:
             if current_chunk != "":
@@ -35,8 +33,8 @@ def split_lines(text: str, max_tokens: int = 100) -> List[str]:
 def split_markdown(
     text: str,
     delimiters: List[str],
-    min_tokens: Optional[int] = None,
-    max_tokens: Optional[int] = None,
+    min_chars: Optional[int] = None,
+    max_chars: Optional[int] = None,
 ) -> List[str]:
     """Split markdown text into chunks based on delimiters.
 
@@ -44,15 +42,15 @@ def split_markdown(
         text (str): Markdown text to split.
         delimiters (list): List of delimiters to split on.
         top_level (bool): Whether or not the current text is top level.
-        max_tokens (int): Maximum number of tokens per chunk.
+        max_chars (int): Maximum number of tokens per chunk.
 
     Returns:
         list: List of chunks.
     """
 
     if not delimiters:
-        # Join lines to form largest possible strings that are less than max_tokens
-        return [(None, c) for c in split_lines(text, max_tokens=max_tokens)]
+        # Join lines to form largest possible strings that are less than max_chars
+        return [(None, c) for c in split_lines(text, max_chars=max_chars)]
 
     delim_match = f"\n{delimiters[0]}"
 
@@ -61,7 +59,7 @@ def split_markdown(
 
     # If there is only one chunk, split on next delimiter
     if len(candidate_chunks) == 1:
-        chunks = split_markdown(text, delimiters[1:], min_tokens, max_tokens)
+        chunks = split_markdown(text, delimiters[1:], min_chars, max_chars)
 
     # Iterate over chunks
     chunks = []
@@ -75,14 +73,14 @@ def split_markdown(
             if prev_chunk:
                 chunk = prev_chunk + chunk
                 prev_chunk = None
-            if min_tokens and len(chunk) < min_tokens:
+            if min_chars and len(chunk) < min_chars:
                 prev_chunk = chunk
                 continue
-            if max_tokens and len(chunk) > max_tokens:
+            if max_chars and len(chunk) > max_chars:
                 chunks.append(
                     (
                         section_name,
-                        split_markdown(chunk, delimiters[1:], min_tokens, max_tokens),
+                        split_markdown(chunk, delimiters[1:], min_chars, max_chars),
                     )
                 )
             else:
@@ -114,16 +112,16 @@ def _flatten_sections(sections, section_depth=0, **kwargs):
 def split_pmc_document(
     text: str,
     delimiters: List[str] = ["# ", "## ", "### "],
-    min_tokens: int = 20,
-    max_tokens: int = None,
+    min_chars: int = 20,
+    max_chars: int = None,
 ) -> List[str]:
     """Split PMC document text into chunks based on delimiters, and split by top level sections.
 
     Args:
         text (str): Markdown text to split.
         delimiters (list): List of delimiters to split on.
-        min_tokens (int): Minimum number of tokens per chunk (for headers)
-        max_tokens (int): Maximum number of tokens per chunk.
+        min_chars (int): Minimum number of tokens per chunk (for headers)
+        max_chars (int): Maximum number of tokens per chunk.
 
     Returns:
         list: List of chunks.
@@ -135,7 +133,7 @@ def split_pmc_document(
         warnings.warn("Skipping document, not in markdown")
         return
 
-    _outputs = split_markdown(text, delimiters, min_tokens, max_tokens)
+    _outputs = split_markdown(text, delimiters, min_chars, max_chars)
     _outputs = _flatten_sections(_outputs)
 
     # Add start_chars and end_chars


### PR DESCRIPTION
- Spitting actually measures chars not tokens.
- Rule of thumb of around ~4 chars per token can be used to estimate when to split