### PR TITLE
ENH: Skip extraction failures gracefully

### DIFF
--- a/publang/pipelines.py
+++ b/publang/pipelines.py
@@ -181,7 +181,7 @@ def extract_on_match(
 
     if not res:
         return None
-    
+
     # Combine results into single df and add pmcid
     pred_groups_df = []
     for ix, r in enumerate(res):

--- a/publang/pipelines.py
+++ b/publang/pipelines.py
@@ -31,7 +31,7 @@ def _extract_iteratively(
                 row["content"], messages=messages,
                 output_schema=output_schema, model=model, **kwargs
             )
-            if not res:
+            if res is False:
                 break
             # Check that main key contains values
             if all([res[key] for key in output_keys]):
@@ -129,10 +129,9 @@ def search_extract(
     )
     ranks_df.sort_values("distance", inplace=True)
 
+    results = []
     if output_path is not None and os.path.exists(output_path):
         results = json.load(open(output_path))
-    else:
-        results = []
 
     inputs = _filter_remaning(
         ranks_df.groupby("pmcid", sort=False), results)
@@ -148,9 +147,9 @@ def search_extract(
         **kwargs
     )
 
+    results = [r for r in results if r]
+
     if output_path is not None:
-        if os.path.exists(output_path):
-            results = json.load(open(output_path)) + results
         json.dump(results, open(output_path, "w"))
 
     return results

--- a/publang/tests/cassettes/test_extract_from_multiple.yaml
+++ b/publang/tests/cassettes/test_extract_from_multiple.yaml
@@ -577,7 +577,7 @@ interactions:
       product that may be evaluated in this article, or claim that may be made by
       its manufacturer, is not guaranteed or endorsed by the publisher. \n\n \n```",
       "role": "user"}], "model": "gpt-4-0125-preview", "response_format": null, "temperature":
-      0, "tools": [{"type": "function", "function": {"name": "extractData", "description":
+      0.01, "tools": [{"type": "function", "function": {"name": "extractData", "description":
       "Extract data from scientific text", "parameters": {"properties": {"groups":
       {"items": {"properties": {"count": {"description": "Number of participants in
       this group", "type": "integer"}}, "required": ["count"], "type": "object"},
@@ -590,7 +590,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '46544'
+      - '46547'
       content-type:
       - application/json
       host:
@@ -600,19 +600,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFZLvQ49gGiX3oLS3Q1IZAU5TElC+Qq9SBoH8vKDuWbIQH
-        YbXDmR3ubh8RAqKCggBrKTJl5TLf8idlsm73+4faxvYVq3armMtk+tw9wyIwzPGVM/xgfWFGWclR
-        GH2GmeMUeVBN0mSd5+tNHI+AMhWXgdZYXG6WcbL6urSOvwn+78JsjWDcQ0H+RIQQ0o/f4FFX/AQF
-        GXXGjOLe04ZDcb1ECDgjQwao98Ij1QiLCWRGI9fBtu6knAFojCwZlXIqfD79LJ4aRaUsf+qXX/pF
-        0fat+q4es3j35OudOH2b1TtLv9vRUN1pdm3QDL/mi7tihICmauTyEzrK8IEivaMTAtQ1neIag3Xo
-        99A401m/Dw/p98BMpzH8rLJhQW4S8V1iHQ+HAW7kh+iz+HCJhusopGmsM0d/11mohRa+LR2nfnzh
-        vNHRh+hhHHx3M0uwziiLJZq/XAfZJM7T/KwL07ZN+OayF4AGqZzxkjjJo4tX8O8euSproRvurBPj
-        LkBty6RaUZ5m9JhCNET/AQAA//8DAKXGLBcVAwAA
+        H4sIAAAAAAAAA2xS22rjMBB991eIeU6K7ebqxxK2FFpK2FJ2twlGVmRHW1nSSmOnwfjfiy9JnLB6
+        EKM5OmeOZlR5hIDYQUSA7Smy3Mjx8il8vE/KH/snmx6S4+d6/rxIw/e3+dvqFWHUMHTylzM8se6Y
+        zo3kKLTqYGY5Rd6oBvNg4i+msyBogVzvuGxomcHxZOwH4XRsLC8FP/TMvRaMO4jIh0cIIVW7Nx7V
+        jn9BRPzRKZNz52jGITpfIgSslk0GqHPCIVWd3x5kWiFXjW1VSDkAUGsZMyrlpXC3qkF8aRSVMj5g
+        +fDH/lvr3w+PZZCUP4tfq/Xz4WVQr5M+mtZQWih2btAAP+ejm2KEgKJ5y+VfaCnDFUV6QycEqM2K
+        nCtsrEO1gczqwrgNRB/VBpguFG4gChf1aHj0r473fr2t4Uq49v4Xb/uoPg9B6sxYnbibnkIqlHD7
+        2HLq2rcNW+ydRLftyIurKYKxOjcYo/7kqpEN/OV82enC5Z9d8HDag6iRygEv8P2J13sFd3TI8zgV
+        KuPWWNH+AkhNvJtNKQv82YSBV3vfAAAA//8DAJqcav4PAwAA
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991d9b8b95e78a-DFW
+      - 87a1e8dd4c7b2cd2-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -622,14 +622,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:16:44 GMT
+      - Thu, 25 Apr 2024 22:53:33 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=0N6X9nnvvjl9lXxLWURcVFw90vBs5vwp9sjIJw7pjfs-1713993404-1.0.1.1-mEpBDiayMjUjFKT2.FmSb6Pglm2R0yqCj6mgjTHTFeLY21mZe2LdryBS7QqB7x.6dTZc83IU1HVQSWmMX01HXw;
-        path=/; expires=Wed, 24-Apr-24 21:46:44 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=OpdGROrHZeK7.P5kzpWqCk47Ly_XiHk2ur1VCyD16ck-1714085613-1.0.1.1-DPU8IZTIUKpPSf3k_w2X9lB8nGWTlnFU57jR.FkSmv2NT5kgUW_4WkiUXWSHD3p1_ZvG0oVhNBlTAjrUZ8AJTA;
+        path=/; expires=Thu, 25-Apr-24 23:23:33 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=1g1PXZa870RePWchsfjND6ay7uYLPkt9u5x8wN4xDBQ-1713993404972-0.0.1.1-604800000;
+      - _cfuvid=TppmLurHeKKG14AUQouxXd_9xqkLRBP4KSlAkuYqG5c-1714085613562-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -642,7 +642,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '4974'
+      - '2374'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -660,7 +660,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 859ms
       x-request-id:
-      - req_92e01f801e4063a45c88da28d4cd922c
+      - req_39eb3dee228b1cf41ef842b27965edf9
     status:
       code: 200
       message: OK
@@ -1298,7 +1298,7 @@ interactions:
       fMRI template instead of the random time-point image as the reference template,
       the registration accuracy has been improved to a certain extent. \n\n \n```",
       "role": "user"}], "model": "gpt-4-0125-preview", "response_format": null, "temperature":
-      0, "tools": [{"type": "function", "function": {"name": "extractData", "description":
+      0.01, "tools": [{"type": "function", "function": {"name": "extractData", "description":
       "Extract data from scientific text", "parameters": {"properties": {"groups":
       {"items": {"properties": {"count": {"description": "Number of participants in
       this group", "type": "integer"}}, "required": ["count"], "type": "object"},
@@ -1311,7 +1311,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '50819'
+      - '50822'
       content-type:
       - application/json
       host:
@@ -1321,19 +1321,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFKctppWOTNC7anHpI0dgQaHolM6VIllylNgT9eyH5Idmo
-        DsRihzM7nFUTMQZqCxkDuRMkK6en6RKfPH/jPz9L/aMKX9LH+193fv/1yb0fOEw6ht28oaQz64O0
-        ldNIypojLD0Kwk6Vf+TzNJ0ns0UPVHaLuqOVjqbJdMbjxdR5fFf498TcWSUxQMZeI8YYa/qz82i2
-        uIeMzSbnToUhiBIhu1xiDLzVXQdECCqQMASTAZTWEJrOtqm1HgFkrc6l0HoYfPyaUT0EJbTO/3g8
-        vLjvz+plc5+W5fLT8llt+Tc9mneUPrjeUFEbeQlohF/62c0wxsCIqufinryQ9CBI3NAZA+HLukJD
-        nXVoVlB6W7uwguy1WYG0taEVZJzzuJ1cN5J23cKVWhv9r16fqvaSvLal83YTboKEQhkVdrlHEfoH
-        jXONzqLrfs/11erAeVs5ysn+RtPJpsk8PcrC8G8NcDw/gWRJ6DHtLo5OTiEcAmGVF8qU6J1X/eKh
-        cDmPY84TTBYFRG30DwAA//8DAMgHDw0CAwAA
+        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFqciurWNQJMirSIE2aBIbAk2vHglFMuSqTSLo3wvJD8lG
+        dSAWO5zZ4azqgDEoNhAzkLkgWVo1XlyFlzNx/vs2f6LJr+ruc3OXfZ9nXj+6lxsYtQyzfkFJe9YX
+        aUqrkAqjt7B0KAhbVf6VR5P5dMajDijNBlVLyyyNo/GEh9OxdfinwL87Zm4KiR5i9hwwxljdna1H
+        vcF3iNlktO+U6L3IEOLDJcbAGdV2QHhfeBKaYNSD0mhC3drWlVIDgIxRiRRK9YO3Xz2o+6CEUsnT
+        /ePnz+iVrsXVm57rHzcPuL7Q+flg3lb6w3aG0krLQ0AD/NCPT4YxBlqUHRffyQlJ3wSJEzpjIFxW
+        laiptQ71EjJnKuuXED/XS5Cm0rSEmHMeNqPjRtSsGjhSa4L/1atd1RySVyazzqz9SZCQFrrweeJQ
+        +O5Bw1yDveiq23N1tDqwzpSWEjKvqFvZRXS22MpC/2/1cHi2A8mQUEPaLAx2TsF/eMIySQudobOu
+        6BYPqU14GHIeYTRNIWiCfwAAAP//AwB+rdJnAgMAAA==
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991dbd9adf477f-DFW
+      - 87a1e8ed5a76462a-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -1343,14 +1343,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:16:47 GMT
+      - Thu, 25 Apr 2024 22:53:36 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=UOKOXVhHwC3GjPscDp1nfXt17RQK1KpZz0VHJU2cKo4-1713993407-1.0.1.1-Z0Sr_B0nkUnfvhXWn0aoBUVUa0ZExfQGq3OvrVxO8R496xuSl8BSmpbB4AG7FQRG7c.VBX6X.oUVmUDL4leh4w;
-        path=/; expires=Wed, 24-Apr-24 21:46:47 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=_Um28CVOMJWtzo66CIkadyF_ZaVRgsuZTavwxwAN_bE-1714085616-1.0.1.1-KhsCkMAL3wwzoQV4m1jK.dG8IP9nlgT9k216RF8dlc8gzqQiKmpKXdkyk_Z2wtlBKRT3kZA0eBl1lGbdlPGWHQ;
+        path=/; expires=Thu, 25-Apr-24 23:23:36 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=PZayX7cZe5niEB1R871OmRolrjhky1Gb9J8iM4gsqog-1713993407580-0.0.1.1-604800000;
+      - _cfuvid=RBa5SFQeqkzmnpblbfq7PkKn8.TXpriCKijIYIP56sk-1714085616440-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -1363,7 +1363,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '2440'
+      - '2623'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -1381,7 +1381,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 939ms
       x-request-id:
-      - req_e85cb66164916fc35c60239b9e160d6a
+      - req_475de843cf7ebaf2e3ca3cee9dafe024
     status:
       code: 200
       message: OK
@@ -1978,7 +1978,7 @@ interactions:
       [MEMRY, Sherman and Brooks, 2017, PAR Inc.]). \n\n\n\n### PEER REVIEW \n  \nThe
       peer review history for this article is available at  \n\n\n \n```", "role":
       "user"}], "model": "gpt-4-0125-preview", "response_format": null, "temperature":
-      0, "tools": [{"type": "function", "function": {"name": "extractData", "description":
+      0.01, "tools": [{"type": "function", "function": {"name": "extractData", "description":
       "Extract data from scientific text", "parameters": {"properties": {"groups":
       {"items": {"properties": {"count": {"description": "Number of participants in
       this group", "type": "integer"}}, "required": ["count"], "type": "object"},
@@ -1991,7 +1991,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '47885'
+      - '47888'
       content-type:
       - application/json
       host:
@@ -2001,19 +2001,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RSy27bMBC86yuIPduFXnZrHZ0ASQ5pgfQSNDYEml7JTCiSJVdxUkH/Xkh+SDES
-        HojlDmd2uMsmYAzkFjIGYsdJVFZNF7d4Uyfi10ZePYSv4fVP43d/tvHyjvRewqRjmM0zCjqxvglT
-        WYUkjT7AwiEn7FSj71GyWCRp+KMHKrNF1dFKS9N0GkbxbGodvkrcH5k7IwV6yNhTwBhjTb93HvUW
-        3yBj4eSUqdB7XiJk50uMgTOqywD3XnrimmAygMJoQt3Z1rVSI4CMUbngSg2FD6sZxUOjuFI56v3y
-        92P5z/x9SEX4cj/ndx4f9XJU7yD9bntDRa3FuUEj/JzPLooxBppXPRffyHFB15z4BZ0x4K6sK9TU
-        WYdmBaUztfUryJ6aFQhTa1pBFs/bydfHJGrXLXwQboPP4vUxas9DUKa0zmz8RU+hkFr6Xe6Q+/5t
-        4xYHJ9F1P/L6wxTBOlNZysm8oO5kozBZzA+6MPyzAY9nR5AMcTXmpXEUHL2Cf/eEVV5IXaKzTva/
-        AAqbR3EcRSmmswKCNvgPAAD//wMAhcof/w8DAAA=
+        H4sIAAAAAAAAA3xS246bMBB95yuseU4qICxseIu02nbVqlqpUi/bRMjrGOLWt9pDuwni3yuTC2xU
+        1Q9omONz5nhmuogQEFsoCbAdRaasnC8f0rfL1SK9f2i/2Q95kT0d4n2b/jo8qc/vYRYY5vkHZ3hm
+        vWFGWclRGH2EmeMUeVBNiiSLb2/ypBgAZbZcBlpjcZ7N4yS9mVvHfwv+58TcGcG4h5J8jwghpBu+
+        waPe8hcoSTw7ZxT3njYcysslQsAZGTJAvRceqUaYjSAzGrkOtnUr5QRAY2TFqJRj4ePpJvHYKCpl
+        ZT5+UtvDV5qulBeP6ePtO3q/uku/TOodpfd2MFS3ml0aNMEv+fKqGCGgqRq4/AUdZXhHkV7RCQHq
+        mlZxjcE6dGtonGmtX4eHdGtgptUYftK8n5H/JhZJv+nhlXwf/SvenKL+MgppGuvMs7/qLNRCC7+r
+        HKd+eOG00dFZdDMMvn01S7DOKIsVmp9cB9kkXizzoy6M2zbi2WkvAA1SOeVlizw6eQW/98hVVQvd
+        cGedGHYBalvFRZ1mBavrGqI++gsAAP//AwD6JPWSFQMAAA==
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991dce0fd9e956-DFW
+      - 87a1e8ff7a822cc2-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -2023,14 +2023,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:16:49 GMT
+      - Thu, 25 Apr 2024 22:53:47 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=D0KvUsBenntcbe0O6ECU5jYl88DUylcOmn6B8CDWaVk-1713993409-1.0.1.1-2ZPv4mKM0BnJgnVYUOW523W9cAdyl3lyoL1h2aFTvDpyg6xJzB2ckV9Av1tA9ivRd1TlhKtD9QubokTvDIB4Eg;
-        path=/; expires=Wed, 24-Apr-24 21:46:49 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=I7xgcj0hUQ7Fc0USy_4lGSbpG3cxne9zEUL.qlK5V8g-1714085627-1.0.1.1-PZTYbgLiyr.rejcmWyNdjLdYeCbmotxgRWtE2bR9ftFR4TgeQE237W_AutzLX1eHuL8fJ2HIGXge7KyRjl971w;
+        path=/; expires=Thu, 25-Apr-24 23:23:47 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=or1eFFvTfnnmDs89U6ELo_h9b3WWIsuT46OUXd9djrY-1713993409940-0.0.1.1-604800000;
+      - _cfuvid=mG9cRLAKlnqK0PBRMtYK84F00wqY_1DmJpaJ_o0RjnU-1714085627232-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -2043,7 +2043,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '2154'
+      - '10219'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -2061,7 +2061,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 884ms
       x-request-id:
-      - req_c5c13e4a5e04de8c1e47c31ada932ed8
+      - req_40869b0fbadd7456807e5d1ffaa7a2c7
     status:
       code: 200
       message: OK
@@ -2328,11 +2328,11 @@ interactions:
       concluded that the affective, predatory, and non-violent offenders exhibited
       different patterns of alterations in GM and WM tissues in regions involved in
       emotion and cognition. \n\n \n```", "role": "user"}], "model": "gpt-4-0125-preview",
-      "response_format": null, "temperature": 0, "tools": [{"type": "function", "function":
-      {"name": "extractData", "description": "Extract data from scientific text",
-      "parameters": {"properties": {"groups": {"items": {"properties": {"count": {"description":
-      "Number of participants in this group", "type": "integer"}}, "required": ["count"],
-      "type": "object"}, "type": "array"}}, "type": "object"}}}]}'
+      "response_format": null, "temperature": 0.01, "tools": [{"type": "function",
+      "function": {"name": "extractData", "description": "Extract data from scientific
+      text", "parameters": {"properties": {"groups": {"items": {"properties": {"count":
+      {"description": "Number of participants in this group", "type": "integer"}},
+      "required": ["count"], "type": "object"}, "type": "array"}}, "type": "object"}}}]}'
     headers:
       accept:
       - application/json
@@ -2341,7 +2341,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '21267'
+      - '21270'
       content-type:
       - application/json
       host:
@@ -2351,19 +2351,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSXW+jMBB851dY+5xUMaFqw+Ppqkbtfaiq1GvVRMh1FuI7Y1v20qSH+O8V5AMS
-        lQe07DCz41nXEWOgVpAykGtBsnR6PJvj7ebxmu4f34lfqfm3m//Fz3mIzbWbWhi1DPv2FyUdWBfS
-        lk4jKWt2sPQoCFtVfsWns9k04ZMOKO0KdUsrHI2T8YTHl2Pn8V3hZs9cWyUxQMpeI8YYq7t369Gs
-        cAsp63S6TokhiAIhPf7EGHir2w6IEFQgYQhGPSitITStbVNpPQDIWp1JoXU/ePfUg7oPSmidzVdP
-        Cafk9wt/sNunzd2v4sfz3f2fm8G8nfSH6wzllZHHgAb4sZ+eDWMMjCg7Lm7JC0nfBYkzOmMgfFGV
-        aKi1DvUCCm8rFxaQvtYLkLYytIA0njSj089lAydKTfRVvdxXzTF1bQvn7Vs4CxFyZVRYZx5F6A4z
-        zDQ6iC67HVcnawPnbekoI/sPTSubcM53stDfqx6ODyBZEnpIm8bR3imEj0BYZrkyBXrnVbd0yF3G
-        45jzBJPLHKIm+gQAAP//AwAnMT5T/gIAAA==
+        H4sIAAAAAAAAA2xSwY6bMBC98xXWnJMKIghdrrvVbiv11FSV2kTIcQbi1NiuPXSTRfx7ZUISNioH
+        a2Ye783zeLqIMZA7KBiIPSfRWDV/+Lx4/rLanvJPK/twSMXBuNe3H9/090ehCWaBYbYHFHRhfRCm
+        sQpJGn2GhUNOGFSTPEnjj9lykQ9AY3aoAq22NE/ncbLI5tbhX4mvI3NvpEAPBfsVMcZYN5zBo97h
+        EQoWzy6VBr3nNUJx/YkxcEaFCnDvpSc++h1BYTShDrZ1q9QEIGNUKbhSt8bnr5vEt0FxpcqXp1Uu
+        5Lbi9k/18026+OiOX73OJ/3O0ic7GKpaLa4DmuDXenHXjDHQvBm4eCTHBT1x4nd0xoC7um1QU7AO
+        3RpqZ1rr1+Ei3RqEaTWFJO9nbJov7/J7fBH3mx7eNeuj/8WbMeqvD6NMbZ3Z+rs5QyW19PvSIffD
+        fadjjy6im2EN2ncvC9aZxlJJ5jfqIJsmSXKWhdvqTeB0BMkQV1NalkWjU/AnT9iUldQ1OuvksBdQ
+        2XK3zLhI4mUqIOqjfwAAAP//AwDyiFJZIQMAAA==
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991ddcde436b34-DFW
+      - 87a1e94308123470-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -2373,14 +2373,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:16:52 GMT
+      - Thu, 25 Apr 2024 22:53:50 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=OMiVwPW8HCKvbOCgnsXC6B6Cl8wjRR_FITegb0IeaFo-1713993412-1.0.1.1-fUoxkfE8XGkhVhhP4ccgFTEg2utTrseVxNL744dDEpK7O.UueqTtDS1UCws2rDLOBbsutgNAda1Mb9K2uvRz4w;
-        path=/; expires=Wed, 24-Apr-24 21:46:52 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=SiGZPYRFrkKg6vgE84QydKkxT3nxchI6lPO32abizBM-1714085630-1.0.1.1-xGplciS5p.bGnMRGIJvHiEt51u45GY9YBu0qE5e8TZS893un81ZK_B5_R5WGoLCjI9Wd_BfO2J_GKJhlI26OGw;
+        path=/; expires=Thu, 25-Apr-24 23:23:50 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=tSUu26TX.4lAa5KIVZHhKg4_IZAG4uYqQl02EHw1iHE-1713993412633-0.0.1.1-604800000;
+      - _cfuvid=myfRVIYJ0mUQGvADStPRi7cvjzl.fiXHyhsTMQF9xz0-1714085630147-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -2393,7 +2393,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '2495'
+      - '2701'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -2411,7 +2411,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 389ms
       x-request-id:
-      - req_9b3195e6faddd47801aa0d1a480d396c
+      - req_4ff02178ea6bc997f0b1072ad7516db9
     status:
       code: 200
       message: OK
@@ -3438,11 +3438,11 @@ interactions:
       the editors and the reviewers. Any product that may be evaluated in this article,
       or claim that may be made by its manufacturer, is not guaranteed or endorsed
       by the publisher. \n\n \n```", "role": "user"}], "model": "gpt-4-0125-preview",
-      "response_format": null, "temperature": 0, "tools": [{"type": "function", "function":
-      {"name": "extractData", "description": "Extract data from scientific text",
-      "parameters": {"properties": {"groups": {"items": {"properties": {"count": {"description":
-      "Number of participants in this group", "type": "integer"}}, "required": ["count"],
-      "type": "object"}, "type": "array"}}, "type": "object"}}}]}'
+      "response_format": null, "temperature": 0.01, "tools": [{"type": "function",
+      "function": {"name": "extractData", "description": "Extract data from scientific
+      text", "parameters": {"properties": {"groups": {"items": {"properties": {"count":
+      {"description": "Number of participants in this group", "type": "integer"}},
+      "required": ["count"], "type": "object"}, "type": "array"}}, "type": "object"}}}]}'
     headers:
       accept:
       - application/json
@@ -3451,7 +3451,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '81762'
+      - '81765'
       content-type:
       - application/json
       host:
@@ -3461,19 +3461,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFaSl1pVuDoG6KIugDCIrGhsDQK5kJRTLkyo0j6N8LyS/Z
-        CA/EYoczO5hlEzEGagUZA7kWJCunx+lXnL8l36837vf9k/rx+c9t+m3uV3S3SSa/YNQx7OMTSjqw
-        PkhbOY2krNnB0qMg7FT5jMdpGic87oHKrlB3tNLROBlP+PRq7DxuFP7bM9dWSQyQsYeIMcaa/u48
-        mhW+QsYmo0OnwhBEiZAdHzEG3uquAyIEFUgYgtEJlNYQms62qbUeAGStzqXQ+jR4d5pBfQpKaJ2L
-        t59Yfym2m7+z6wLnL0V9LymdzAfzdtJb1xsqaiOPAQ3wYz+7GMYYGFH1XHwlLyTdCBIXdMZA+LKu
-        0FBnHZoFlN7WLiwge2gWIG1taAEZj5N22cIZt43eq5f7qj3mrG3pvH0MF7FBoYwK69yjCL39YYrR
-        QXTZb7U+WxQ4bytHOdlnNJ0s/5jGfKcLp680wGd7kCwJfcZLPkV7rxC2gbDKC2VK9M6rftFQuJxP
-        p5wnmFwVELXRfwAAAP//AwCZGcr28gIAAA==
+        H4sIAAAAAAAAA2xSwY7aMBC95yusOS9VAiFZcmy327Iqp6qt1AVFxgzBu47t2pNdtlH+vYphIaD6
+        YI3m+b15euM2YgzkBgoGYsdJ1FaNZvPxl8UiX/CXh4/5/f04mcX7hx/66c+n3+uvcNMzzPoJBb2z
+        PghTW4UkjT7AwiEn7FWTPEnj22k2iQNQmw2qnlZZGqWjOBlPR9bhi8TXI3NnpEAPBXuMGGOsDXfv
+        UW9wDwULOqFTo/e8QihOjxgDZ1TfAe699MQ1wc0ZFEYT6t62bpQaAGSMKgVX6jz4cNpBfQ6KK1Vm
+        z9Z/+/tqPudzrdJf85/pevp9fycH8w7SbzYY2jZanAIa4Kd+cTWMMdC8Dlzck+OC7jjxKzpjwF3V
+        1Kiptw7tEipnGuuXUDy2SxCm0bSEIpmk3aqDC24X/a9eHavulLMylXVm7a9ig63U0u9Kh9wH+8MU
+        o3fRVdhqc7EosM7Ulkoyz6h72SSbTZKDLpy/0gDPjyAZ4uqCl95GR6/g3zxhXW6lrtBZJ8OiYWvL
+        TTblIomzVEDURf8AAAD//wMATfzZbvICAAA=
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991ded9db4469b-DFW
+      - 87a1e9554a3d6b29-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -3483,14 +3483,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:17:03 GMT
+      - Thu, 25 Apr 2024 22:53:53 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=pV0O5zwSyG77ESFRnVdADD.hjMevwA.P.Jb_rUaVaO8-1713993423-1.0.1.1-eKSJDwaI3Wj0bnZAnKvIJ7SD8nbJt6RR4VgFl9AkwCP2flNSbQO6oP1khjJ.3c8inZo1RpZXr192H3ddEsz_gA;
-        path=/; expires=Wed, 24-Apr-24 21:47:03 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=W6IJc0KeuO8KGc_.nSqqF8oAE.sptgw4V8NEZMthMFY-1714085633-1.0.1.1-U17_hyUYDmimwUX44n6b_p1cZ.hVe5tL0f0p9iGgP2GgW6KNjsJFipx6joLNqcSV0BA0soc7O0SdxqjUMmeuHA;
+        path=/; expires=Thu, 25-Apr-24 23:23:53 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=nZZyFRtuR9LW5bvzKOoRD.7.m7vhAzwLqZxE8Fi_06g-1713993423191-0.0.1.1-604800000;
+      - _cfuvid=dmJlcZtrlC34HzY5gJ3lvxCChfSA6kuqBoJm_ObOl8c-1714085633620-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -3503,7 +3503,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '10285'
+      - '3179'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -3521,7 +3521,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1.517s
       x-request-id:
-      - req_2a7e6578e71d634a0dc6d02e66e50202
+      - req_c15f78166603fd93cd675fa38f7b521f
     status:
       code: 200
       message: OK

--- a/publang/tests/cassettes/test_extract_from_text.yaml
+++ b/publang/tests/cassettes/test_extract_from_text.yaml
@@ -549,7 +549,7 @@ interactions:
       product that may be evaluated in this article, or claim that may be made by
       its manufacturer, is not guaranteed or endorsed by the publisher. \n\n \n```",
       "role": "user"}], "model": "gpt-4-0125-preview", "response_format": null, "temperature":
-      0, "tools": [{"type": "function", "function": {"name": "extractData", "description":
+      0.01, "tools": [{"type": "function", "function": {"name": "extractData", "description":
       "Extract data from scientific text", "parameters": {"properties": {"groups":
       {"items": {"properties": {"count": {"description": "Number of participants in
       this group", "type": "integer"}}, "required": ["count"], "type": "object"},
@@ -562,7 +562,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '44259'
+      - '44262'
       content-type:
       - application/json
       host:
@@ -572,19 +572,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFXk4q3ZIUbdoCOQQFCjQ2BIZePWKKpMmVHcfQvweSH5KN
-        8kAsdzizw13uPcagWkLKQJScRG3kNHnEH2/bRO1mm6d6vf53d1OXmzVtHz+C5gkmHUO/vqGgE+uL
-        0LWRSJVWB1hY5ISdanAbREkSRcltD9R6ibKjFYam8dQPwtnUWNxUuD0yS10JdJCyF48xxvb93nlU
-        S3yHlPmTU6ZG53iBkJ4vMQZWyy4D3LnKEVcEkwEUWhGqzrZqpBwBpLXMBJdyKHxY+1E8NIpLma3L
-        UPze/lrFq+Xd94fnj2d1/9P/Q39H9Q7SO9Mbyhslzg0a4ed8elWMMVC87rn4TpYL+saJX9EZA26L
-        pkZFnXXYz6GwujFuDunLfg5CN4rmkIZf28n46F8cI79dtHAh3Hr/ixfHqD0PQerCWP3qrnoKeaUq
-        V2YWuevfNm6xdxJd9CNvLqYIxuraUEZ6haqTDfzYvznowvDPBjycHUHSxOUFLwq8o1dwO0dYZ3ml
-        CrTGVv0vgNxkQRgGQYzxLAev9T4BAAD//wMAW1MDFg8DAAA=
+        H4sIAAAAAAAAA2xSy27bMBC86yuIPduFJMuNo2PzKAIkBRq0SNDYEGh6JbOlSJpcpXYE/Xsh+SHZ
+        KA/EcoczO9xlHTAGcgUpA7HmJEqrxtcP8f0mLydfftjXb79m8f3qTobPIX96v3UWRi3DLH+joCPr
+        kzClVUjS6D0sHHLCVjW6ipJwNp1ezzqgNCtULa2wNE7GYRRPx9bhu8S/B+baSIEeUvYWMMZY3e2t
+        R73CLaQsHB0zJXrPC4T0dIkxcEa1GeDeS09cE4x6UBhNqFvbulJqAJAxKhNcqb7wftWDuG8UVyrb
+        7F6+Pj59f/j58qi2N8/bq9fiQ0eb5aDeXnpnO0N5pcWpQQP8lE8vijEGmpcdF7fkuKBbTvyCzhhw
+        V1QlamqtQz2HwpnK+jmkb/UchKk0zSGNZ81oeAzPjpOwWTRwJtwE/4sXh6g5DUGZwjqz9Bc9hVxq
+        6deZQ+67tw1bHBxFF93Iq7MpgnWmtJSR+YO6lY3CJPy814X+n/V4PD2AZIirM94kCg5ewe88YZnl
+        UhforJPdL4DcZlEcR1GCyTSHoAn+AQAA//8DAE6fD8oPAwAA
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991d89d97545f3-DFW
+      - 87a1e8893d7b4740-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -594,14 +594,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:16:39 GMT
+      - Thu, 25 Apr 2024 22:53:30 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=p7UdVeqScNE4JLdmXW8avE0dAJsrY1Q1U9zhcwcIW4c-1713993399-1.0.1.1-cNSi26Q3aSjoRyUk5xGj70dYjj7wjelI4mG_TagRIkyy6_WMwlQ7_RqEH7orG8d9SvZZ9blHdrQslfqtwYzOhA;
-        path=/; expires=Wed, 24-Apr-24 21:46:39 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=DdFDHBlNkmZ0JY0lNgGNr13m00YwRLejZjjEqNITq6g-1714085610-1.0.1.1-xuREDrHPqjba3CGCGS4u479.ifxtDEUxoOuCZRGTGiu07XUNNs.bqEvU1A5HlqzvAmUz7dVNOnuQpbAPlGrbUg;
+        path=/; expires=Thu, 25-Apr-24 23:23:30 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=JI4h6.Vpn4pbERqkS.Huu9YV0_s4UDiSKUDvK3HwON0-1713993399492-0.0.1.1-604800000;
+      - _cfuvid=GnZEqv52KFXP7q738OVwjivwC2I.lPZvNlNNSwuZOQM-1714085610931-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -614,7 +614,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '2561'
+      - '13065'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -632,7 +632,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 816ms
       x-request-id:
-      - req_9db3497f1aeaece3df15c8036c4d4306
+      - req_4708ab44f1f2a272925268e8cf4d0aa1
     status:
       code: 200
       message: OK

--- a/publang/tests/cassettes/test_get_openai_chatcompletion.yaml
+++ b/publang/tests/cassettes/test_get_openai_chatcompletion.yaml
@@ -21,18 +21,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA1SQS2vDMBCE7/4Vi85x8CMhtW+ltM0haSgtlFJKUOy1rVbWCmlDEkL+e1Ge9KLD
-        N5phZvcRgFC1KEFUneSqtzoupjgtXnaT+ezxrku28+JzM1/MmsVD276uxSA4aPWDFV9cw4p6q5EV
-        mZNcOZSMITWdpHlR5KMsPwo91aiDrbUc58NxzGu3ojhJs/HZ2ZGq0IsSviIAgP3xDR1NjVtRQjK4
-        kB69ly2K8voJQDjSgQjpvfIsDYvBTazIMJpj7fcOIUuyBD7I6Rre0Cn0sJEeOtQ1SIZnTSuEmWoQ
-        nlRgysC908q0TGYA77iVfijO4YdrK02tdbQKC8xa6ytvlFG+WzqUnkxo4JnsyX6IAL6P69f/Bgnr
-        qLe8ZPpFEwKzySlO3O59E9OLyMRS3/hoFJ37Cb/zjP2yUaZFZ506naKxyyrLijFOclmL6BD9AQAA
-        //8DADko2TEUAgAA
+        H4sIAAAAAAAAA1SQS2/CMBCE7/kVK58JyoNHya2XQqXeQFS0qpCTLIlbx+vai6BU/PfKPNWLD994
+        RjP7GwEIVYsCRNVKrjqr48lzNlu+jSb5oV7R3NfNUk3T2XJPq8P3TvSCg8pPrPjq6lfUWY2syJzl
+        yqFkDKnpOB0kD8Nxkp6EjmrUwdZYjvP+MOatKylO0mx4cbakKvSigPcIAOD39IaOpsa9KCDpXUmH
+        3ssGRXH7BCAc6UCE9F55loZF7y5WZBjNqfaiRciSLIFXcrqGOTqFHnbSQ4u6Bskw1VQivKgNwpMK
+        TBl4dFqZhsn0YIF76fviEn68tdLUWEdlWGC2Wt/4Rhnl27VD6cmEBp7Jnu3HCODjtH77b5CwjjrL
+        a6YvNCEwG5/jxP3edzG9ikws9Z0PBtGln/A/nrFbb5Rp0FmnzqfY2HVeToajWuajUkTH6A8AAP//
+        AwAlYePoFAIAAA==
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991e2faf19a91e-DFW
+      - 87a1eb0e5f2d2cc9-DFW
       Cache-Control:
       - no-cache, must-revalidate
       Connection:
@@ -42,14 +42,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:17:04 GMT
+      - Thu, 25 Apr 2024 22:55:01 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=IsqtrMJqcsbYtPotFb6SiElWCiyg6J900tO7UclsDXE-1713993424-1.0.1.1-2p2BNNJTtFyEnYUsHCjIvrA5okd0hv1ePnmiHUADvmNzKc.G3KZSoZAyf4DMBSeZYt.FEHN45x_hvnnULEMG8Q;
-        path=/; expires=Wed, 24-Apr-24 21:47:04 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=ejE59d6jHiC3ZSoTuRuxASTvo_XklnWA4gAdvLt4DYM-1714085701-1.0.1.1-4nycdFL7J2ftidCmprnIqvKEb0jlVGTQiIslaXIH1e9Vm_tjdg1ipHehuIW3dufnqwmQWFxRMwqCIR5pE_l8PQ;
+        path=/; expires=Thu, 25-Apr-24 23:25:01 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=MJl.mVR.MabqOcQ9xVqebijPsMlOLbKDRe6cPBNsyyA-1713993424141-0.0.1.1-604800000;
+      - _cfuvid=LjBqTU8JeNBZnRESC93ZyZORobxd4bT3ZpnrsqyLODA-1714085701591-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -62,7 +62,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '775'
+      - '587'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -80,7 +80,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_535eec38edad729593e3c4e9afdddd57
+      - req_8fa06282a564497794d81f975b2244bf
     status:
       code: 200
       message: OK

--- a/publang/tests/cassettes/test_get_openai_chatcompletion_function_calling.yaml
+++ b/publang/tests/cassettes/test_get_openai_chatcompletion_function_calling.yaml
@@ -2,9 +2,9 @@ interactions:
 - request:
     body: '{"messages": [{"role": "user", "content": "How many fingers does a human          hand
       have?. Call the extractData function to save the output."}], "model": "gpt-4",
-      "response_format": null, "temperature": 0, "tools": [{"type": "function", "function":
-      {"name": "extractData", "description": "Extract data from scientific text",
-      "parameters": {"type": "object", "properties": {"fingers": {"type": "integer",
+      "response_format": null, "temperature": 0.01, "tools": [{"type": "function",
+      "function": {"name": "extractData", "description": "Extract data from scientific
+      text", "parameters": {"type": "object", "properties": {"fingers": {"type": "integer",
       "description": "Number of fingers in a human hand"}}}}}]}'
     headers:
       accept:
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '464'
+      - '467'
       content-type:
       - application/json
       host:
@@ -24,18 +24,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSXWvjMBB8969Y9jk54jof2G+lzVGOlkJbrnCXYhRl47gnSzppDW1C/vshO7Hd
-        cH4Qy45mdjTrQwSA5QYzQLkTLCurxukd3V0XpfuevJrkev9zsU9/XT29Tvb1M7/gKDDM+p0kn1nf
-        pKmsIi6NbmHpSDAF1XgRJ2maTK+mDVCZDalAKyyPp+PJPE5OjJ0pJXnM4HcEAHBozuBNb+gDM5iM
-        zp2KvBcFYdZdAkBnVOig8L70LDTjqAel0Uw62NW1UgOAjVG5FEr1g9vvMKj7gIRSuVM38fLv4+zx
-        x/79YX0zf9rY2+3yfjmY10p/2sbQttayC2aAd/3sYhgAalE1XPpgJyTfChYXdAAUrqgr0hys42Gl
-        AVa4LXVBzq8wg9lKH/EL5xj9r347VccuX2UK68zaX8QVxEu/yx0J39gephedRd+abdZfFoTWmcpy
-        zuYP6SC7mLWi2P83PRjPTyAbFqrvp3F0con+0zNVefta68putdEx+gcAAP//AwCfDRDb0QIAAA==
+        H4sIAAAAAAAAA2xSy07DMBC85ytWe25RTekrR4R4CQm1FKpCUWRckwT8iOwtAlX9d+SkTUJFDtZq
+        xzM7ns02AsB8jTGgyDgJXaju5Ob0+mnaHxl9sXhgQiyfp4vb2dedGj72l9gJDPv2IQUdWCfC6kJJ
+        yq2pYOEkJxlU2Yid9caDUY+VgLZrqQItLah71u0NWX/PyGwupMcYXiIAgG15Bm9mLb8xhl7n0NHS
+        e55KjOtLAOisCh3k3ueeuCHsNKCwhqQJds1GqRZA1qpEcKWawdW3bdVNQFyphKWMzT/OZ/oyS+dX
+        9/fLMc/Gdjhvzaukf4rS0PvGiDqYFl7346NhAGi4LrnymxwXdMGJH9EBkLt0o6WhYB23KwOwwvfc
+        pNL5FcYwWJkd/uHsov/q1321q/NVNi2cffNHcQXx3GeJk9yXttvpRQfR13Kbmz8LwsJZXVBC9lOa
+        IDsaVKLY/DcNyIZ7kCxx1fQnLNq7RP/jSeqkem3h8nq10S76BQAA//8DAK7Bl9LRAgAA
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991e359eafe813-DFW
+      - 87a1eb13cb772e71-DFW
+      Cache-Control:
+      - no-cache, must-revalidate
       Connection:
       - keep-alive
       Content-Encoding:
@@ -43,23 +45,27 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:17:05 GMT
+      - Thu, 25 Apr 2024 22:55:02 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=9c6e9Ne.HzXk9u2VD853K5pnFLEdQ8T2K2S17sxvTDc-1713993425-1.0.1.1-gsKTrsDSSuweIIEKyD2zKPX5zAp23W67.sqra9ltPTVzDy.aGv_bOdIzEoZtd95vXFCA9rpo6z4FJEiHjztQDw;
-        path=/; expires=Wed, 24-Apr-24 21:47:05 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=KWRtXaB5F2m.cTRBkEKQOzzvqtyNQ7yIVFooh1R.IlE-1714085702-1.0.1.1-OQ09zMkJSO6qrI84hZH9V1DQWj8etberbVYR3MpOABLrlAW6lwMC3_QwDk7l3fZw2DyQa___2v4TZ02MBAYjHQ;
+        path=/; expires=Thu, 25-Apr-24 23:25:02 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=xYBIv_43KU4x70WDWce.SHx5XeUrXdqN1JH7nNThWJ0-1713993425804-0.0.1.1-604800000;
+      - _cfuvid=iMMnehrOfoPqvwzOgzdLeYxKLuerEvW_aC8.srKy1Hk-1714085702885-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
+      access-control-allow-origin:
+      - '*'
       alt-svc:
       - h3=":443"; ma=86400
+      openai-model:
+      - gpt-4-0613
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '1442'
+      - '1076'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -71,13 +77,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '9999'
       x-ratelimit-remaining-tokens:
-      - '299957'
+      - '299958'
       x-ratelimit-reset-requests:
       - 6ms
       x-ratelimit-reset-tokens:
       - 8ms
       x-request-id:
-      - req_de7251bbfb7a97883ab890308f2e9c9c
+      - req_c0ef1ef250d0435f6586079d9a1eea6e
     status:
       code: 200
       message: OK

--- a/publang/tests/cassettes/test_get_openai_embedding.yaml
+++ b/publang/tests/cassettes/test_get_openai_embedding.yaml
@@ -20,121 +20,121 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA1RXy66rOhKd36/YOlNaCiGAzZkRIECA2BDyID2ChBAIj/CwMb4/f7X3aXWrJ5Zc
-        roG9XLXWqr//+vr61WVVfp9+/f76VZfj9Otf37FHOqW/fn/9+6+vr6+vv3/W/8vMmyx/PMq2+En/
-        OSzbR85+/f4S/xv5X9Lvr1/rPNuhOgEoJuL+LMGiHPc027buMD+n/QhwvmPUvPe6Oar1sQQH/xpQ
-        i0+w4mcmJOATHl3qbR7NMD9Es4CrPcuJMGsL56h2StgOrorto3GomF1GCK6d+ESGPH2b3FsPItjG
-        05oah1gDI8yTEaTT0aToaO74Rv9oKQSlRTDq7PUwditFAH3zamlwCHE836Ciwvxu1wgk+9Dnnnab
-        4bLXXBrExlBNDUlHYNZ7GwHtxHxqBg8VWruTi91HNsXTz30kxzwQlsM+nm9FKsLb4exSaxOdM2YE
-        WARlcbxTI0wE0EjeVtAEsQ0w7mWBLw+QpbCryQvrJ6DFRDLuBgT6O8GH22Y3zOGhf4NIUVpsHswL
-        X5wLuEByww7eL+nHnP3Fl1WyyXuyFmyaTZWvhnBZ6hCNjdkDnh4eFnAehox2w9sBPDnlMsxtOaYX
-        +jkD3rltANXyssaHlRTH0ycECLyMWMfWE7x8/oGJDatEruiujjmf5jrR4VnSRuy7BwY43p/ecFK1
-        N9IOT93cnPduqFzWSUTP/HEe2CnsPHCYxxf1otPFn4/ZTYVWtiFIqqIw4+IHLWqkgBYfVGtjdqTL
-        JLgxixg7MrX8zuVzrm1SUyFE0c2Mb0vQqLd5FjDiPTE/z0AlEOhNgq1PM8RcsaY7mCAw6bblTkXf
-        gXsCsdWF9HFLJsAzJTTgTll7FItINOfTKbTBitlHovRSGPf5s8i1hDo1dlbng892O9WF9jtl1HkR
-        C7CxSe7q8PQJDsrn0ZzPu+IC3jKOCdOlPl6mza0D4LZ9UO90u5rLkhwagEMzQptoaSqe2XEI+Uc1
-        kXiVw2p5hvOoHbUiJ6o8DzFDphIC8DYO1ADnuzlW4/YInTNwEOtaceBa7Mow1o5XvLe91lz6gxlC
-        25Az6mrxByyf+e1BYulrJOPIzzaXi3+HF1pziiv+4IsiJicgCRcdbyf15s/FkgvQtEFFA7PemUvR
-        byzQeZRhV9Z38czSMFAy4Rzi7R5hMF+p9wbRo66oTy5GzMgYidq8bV3s+Yd3xQrBUFcFWXvf+LcV
-        M6pbByVXGBGoJrfiKsEjKIvwjsMyOsZvdl0VEH0uHUXJh5qz9Wht+GDjlprXzwpMH1M2IJVfG7Rk
-        j+fAlSBLwew9LwjC+pj9qefIRCu6fWalz5TunUCnsfbYv1x5NbI0QfAmbhkNtGrLRZgnBIBguuF9
-        XQ18DKq7Cw7+OcCX5fbiS8iiAsDgeUSdNOkVC8DThb2a1tRN3A6w7MBdyCXkUF3MLb7cmz4En6i+
-        IzXiE5iWSxeC9uj0aNNe8nhhTydVM1eD2N6MTcw+2+dF6ZuqRWqweplzkDUB/KwkgQSTO3DiyrRT
-        pyydsCnqYtbXbHyDaOflNACsjvm7UHLoEWRgDJvbMDJPvEAcbiPq3DM9Y3xuevjDN0g2OCey+0hg
-        JlxDjFx088d49g3QuyrGRj5W8dIuyQg1OugESHj2Z+539589tbaDkC0uVv7wL9IUWprjJY3uGgjo
-        DSl64gG+8ekRrnu6x/ZCJE4Vq87hpGcCKf3hbTLqzgLUBTjgIEsjs0vgYQaqseekS9qiWi7kXfx5
-        /zBDv1o/A3WEgd/G9Pt/wLTv0jcAdzmjYSTd42Wi1QjvgrOnLjyrcdfvQALfUixiF57TjIknMMI7
-        gy71jsddtbAnTsD5mqwRV+fCnNP92oNaUmEEq8drmM9SkADhbJzxjx6RW7JA9TzWDpHn+1h9870M
-        8u1O+tGfYSnvzgloyOuxkcFNNq7VKwSr04xIJpEWdGTezjDspJR6V3Xl97z93OHQoRXazCMfCECX
-        GZIyTKi3WcAwo0C4Q3XzcmgQv8xsXH3oBdSn6kpdronDUgt0gc1eHnDQl2W1MFIdYWhPCpL3T+zP
-        jqOVUFHIRK1WJJxN124EsiKI9IcPKb+bDRSS2KW6M6YZuZpnAh67AGCdunjgVycjcHu66KTOus+w
-        RAe5A2dpNRLt2kQZRfB2gs/rqsDWniBAFt9IQAwuMvbxcRnmKS4JtFMjwLs6jvn8ym8CtHYXl/Dr
-        Z8U/TN178LkKYyKJq8Hvo/I1w5eFntgMcG+yRtI7eDZQhd3zRhyYfu4vMBBx9qefP/ix6uFJM0Kk
-        aGbJGYJmCD/5qUPFbv8CnwN1LdiGywW74Xs2Z2PMJfWiGxo1koxmfFYGC5RoryIxz2+c27aLYDO3
-        J7LZp1uTo7YINBUkO+yRZh+LpItFuMlWCT1Qu8v4yrq58PgMAd7KVmayfq0jSK5xR1pnH3AyxlYP
-        LQ1i/DSdU8XcRCBAdF4Z1vvPhnOJdRKsj7VM1jpcVQwlfQJt20dEUlkbj8NReEMhtiRq3v0um4rd
-        rKrSbkeo0di3eN6z5wLrJDljc/fM/dmaPAjREDr4uEY9nzVcQLi42w8CxWs9jJNli+DQfkLqnBIK
-        xoheVLhmEkBr16+yz04IPFgRa00PV0ep+D7YNlrXqxxJN5DFVGhVAxTWvaF+ThV/0supUL/9DvWa
-        SgbzDm1OavN5lkgxGhLT02N3hKrKVbqzbzaY4ZCpwFy9evLDb899sH3DPsUVkoutNPBVdDrBOxNc
-        onp4bc7dfLF+/Bsp11M5zM3mKkOBpgrGvsAAfaxuKZwToqB1ZBRVnXdTDw5rlVNTaLR4PEWbFH7r
-        DxJp4lRU3UWN+mBki1Zx6VVL0vajusm0hJTxm/H5FK0SeH9uGqQFhsxHFAi5qknL8qNn2Y//05Ij
-        L1GTKh6f+rUbwENer6gl453PynZCMPhIErVwMfi88eIF7iWACVX1MJ7c+JPDs+Ua2G2YES/4XiSQ
-        puoTScOpAD/9DHo1qbEJTQuwYc8SuLGZTeSiQPEMEBRhMCxn1I0y53TEpxFKbYAp5qnjc/8my8C9
-        vp/0cIdNNctvkqitcJuwi+KMz+41SuHDfRKM8syP+XUpS9g4qwDB2PAr+hJCASYLfBP1fncqtlkZ
-        FtDG5PCfekBilQIx3jyp14mTyQb1cVdvLZ2I2lQJ4LPdXGAaCvofP0qvapLD1/nFqT229cDaENvA
-        0gRM9QCVgK20LYLUXAhFUrjJZjMcVDi/Fo+oae/7jCoPA7Rn2FF7dA9AjOxugWuhcYgcmS1nz1PR
-        gR//883HA63X/Rt8zxeIyVbms6OLbDhfWIoDzfJ8JlvXBO5JvkdKJr8G2kfbELLAI1Q/73RTNMEy
-        gm88sPmupu/5AhfqsawoWt2JZn7jTZQ1X1KSycU7Y7vd4imRttREw5M5LLKpe8CXTwU1xDDLOq/W
-        R2i/E4btIGQxO1DXhmd0fqPoU1vm2sgGAl1CQuwSX47/AQAA//9MmskOszq2hef1FKUzRUcBQrBT
-        M/oeTCCtdHVFFxKaEBobsFTvXiJ/6eoOCYPIxl57rW/vbq+sGqguahOslSzE67sopaMJojS4DmcJ
-        cIsoO6BsGEiQdFjUMeUEDcrNcA6OWvcGDeBjDHYmtyM6hX5Kk4uqiIC7vTCriW/19wwiAw14f4ox
-        mCJl5v/svxKc/HhZh0cCltdbJUowNy4VuWMPuI72mEjJI52rOr4eF8/C5HH+Mi5Wny8MLA7t8YH1
-        mor2dnwF7d0JgrJ+t8NMbXOFgvHeYfyJumHWmosCLK8hmNPTfbyoc8bC07NSkCeeC5XKF+EO4S1T
-        glegwOGzrq8ITocuRDr+dmDSGc351W+kjHwT08PZPsPHZ5qIAauKrqT7CuI3DC2iWfMz/eMHYq0P
-        iSmQ2l1uKbNCBqE9ft/Fj0qa470EaST7wdo3J5duz5C5nyyk6IfPf+vlYyodlJgO685iPtbQofcL
-        8mL+Hm/vMVyurxiL8h4N6x2m7O+8B/R1rKtVsz0JTngoMa80prt+9fwsgoeaI3l2p3Qai3cJaqrK
-        wW4FJMVXPspAbzAzkTQ3Sr9zYASQEuMS7KpjOSyIswtoXg4mUuBaDTTJZua41Ufi6SNfNeyZjkfp
-        3JqYm65avGgegJBxj1rAsyWNu/xWZ1DXDZm4OsyHUfnI9ZHloIQ0VLouDQsdQ7fXjvgL60ElBuav
-        sBv5iKi+yoOePbkz3HenLNhnaZkuou6WwFR3HZG/xhjTziKBmJwDSpB+78CcFjgEi3yTidqzL0rl
-        wCngO5h1FD69JV5Dvl3h9h6Drm5VPEeeJ7KfMSdGLmXpoHUQwhufF1hk9nBo+ITToLfGEE/P7wtQ
-        xZR6KA3mhJkKE7osppfAp6jJSI046pLn/OrgO9XsIHSWNF5r/9ZCNcMSMbzwFE/rcErEx8kz0Znh
-        AhXfwGcU+yaIiWuX13T2UhxAWhxikt/Mx9AveIgA7wguKWT77i6f0DQA8uYc6cajpXO8FyCc3uWT
-        SJ/6ShdcDwJk9QYSNPA4JWVUSJB6RxZ5CTikdF2/IUzCC4eFLT/8eIXYh5JMzMV107k20Pg7n0i7
-        aSpd2/69wkuZGchPPLGiFctkMC3WB1L8XBooOilvmJ0WA907zXR/eVbUwfrF4is8p2v/gncIp12H
-        997z7c76KZTg+VGn5KHqrUvcyGHAqSYXzHaxQWd89Bj4sBye6Hq6Tye+vzNQOtdmQJeDQudHZ61Q
-        SzmM1/Tzjpf9ztFgZyc5FiZeTbvmUrXQUhKfOPacp+u+AMZvvcQdD6k72V1UH4fj44S0R++765WP
-        CljuJC/YY3Hv0iKd30fL+xA8Ccs6YPZ+GMUtPyPz2sbp9LlxEtxDJwl49RHTjlN0Bs6XwiB6sw7V
-        DES1B1u9RHK4dtWUEVLAvMoKvP/I37hbbvsSCgfIEs8tIkq5i70Cmz8gYgqhly47Lo5+9QMXGy+a
-        v+fBgrG0RMTUwDcdt/0T/eKzw6JwohX5PhcF1t/jjKRX3gxLZBka1KAyE/O0tgO5LEwCyje2iS8L
-        PCXS4RHBeXF3wW7jDfS29qV4k8cLsq9Gk06Ik7ND67sFnneVXs1vkw1Fmyw5saabW01Sfg/B5XE9
-        E5+InLtu+wPiEp5JhDt5mLu5MAAjZA6Kb98nnfNnksC8CF3ivZkvoEMjJnuZCvstzzfpVr8sOIDn
-        irmcAHUq+QzC2503iFflcjX65teDv/23LxYHSDAeM/jzF+Oahulq0ugOr8KgIXneJSrFocVCpHcj
-        cjd+1m88A9yj5Y2su2WBBTB2D9becvCH4bl4eu9lDYxapQYkQK27fOXbFRIECLF3LUipmh5WcHPB
-        ngSK+RmW33lEcxAjz+gNdwkVDwP88M1AQLOq7qvSP//hL7uoTt0VewoLo/oZBPNOEIfJf44BHOtR
-        R48FLPFUfk/zUV5294CxPWuYh95KoBwlL7wvT/mwOod4hso3dFGQ54B29sHHvzwbAC5VY070lkz8
-        6YEy9ZG6UHMuj6aEuSCL+XtKaabWkJ3tCkmj6KmEYbkABCYf4Sf3Eqo/euKw5IuCU43dBeW7Dmz1
-        kJxO7SX9NtqcQbL3KmLd8xys3vpgADPlCVL9Nx6IVQYtHEC+/vwYXbLVcoCWUx8hSa/jn58Hb3yF
-        wXJQ+gGf3t8VhuZZI8+oBu5sW98OWEA6Y77W83Rh7jD4w49M+RYOVCBseKjvXYbFZ7Gni+TDO7zG
-        8YxrOmUVJZerAV/77owUI4Bg8hyqgX7X7n/6Ey9XWUjA7N25YA1VG6xElyVxy6N4eAYzoA+dOD/e
-        hPmNh2DLUlvAuvcH2eo/HTg/5kXWLsRgu7/pGJzr5KcXeJf7Z7C6b96Ao5XIuCeHCeBNr2ETfQQM
-        QuM5TG1bzzCv6UqQvi8rKsBdIX502iJdT28x3fgtQB9bQcaB3uj8bNIV4NzQSXC9i+DbPd8QtOub
-        Ejc0ntUMzEAEG38i1tAgd2HcRTrqb/IgwWy3brve/Rq0bBaRKK5PYJ6PiwEtKcPElASBLsQSGLjl
-        ZWJt+WcFTdmCZM2ugbDl+yWP2RJu3wM9rfwLvnM/RfD51E/ETh82OHxVQYJNHKhId8ch3fyuBmU3
-        JMjnSyb+7S+Ae+WAV9Mb4zm8hCU8WMGN/PjQTLxShMMShcHBR5Y7W3XWAkGNPOSWnlSxj6mQ4Pf0
-        yZDDvD/DTNW1hHFq8xgIsldR/fsyoHoSY8xs+sgeUcfAlc8C4p/rl7s0J9D/+A0yxAhVf/QgNK8a
-        zi7dmc77WxUcP26rEsViOrqMV1hDbmEBcmVrpitouvaP/kjJXRuWR9YLP71HRpJQda3rVwLTQcuR
-        rbQ4JdfK6EBNVp+4aS+ov/4B/DZFgu9XrlbpefxagvoxGjy/5159pZevAS+3hMPsK9ApWXp6/sMX
-        ncetraZ6ams45m2Mc353VWfheXKgftg7xHGwB+Z2/xQhMls3WKtyVifnFa7HJY5KZPe3+7DlowJm
-        PXslznZfaFQs/L6Umi6go9kOC2h3rHAR+T442uAT0yl7ijAZzjUJd0JSLVQ4tzC9CC7Rrs3obutJ
-        Dj+eoZlWU9FzTT2Y2HxApEdycZdX8pZAMoUq0l5BA+YM8SXsVqlBmXvshzHlZg1Sty+D3WRTleqJ
-        H/zqOTkrDq+OzGhJ0CY0R0ol3+P1KWfsT9/xoVWqYb46XA32iXwgcjXf1P1DeojglJxnUlD3Gg/w
-        owvA/9aE2NF7HP70V2p/GHF8Mcx41fOjBXxmkVHuveYKu/0ogTid5eDzke14CU9dDfSSisR2GAqW
-        jj0bcKikCYViKLvs+mwyKD4NOXjNO9GlBubPcPPPeJcaavrwHKCJ4Q66xJLbVzrvlksIx53xJfrG
-        V+bG5zrQdcczMRNndNekYRxIZA6RQGJVd2FORghYOxOR2672wB7A7B2Hlx4gncM24Pc334K3UTsg
-        Wz2sAGf4Hhz1I7a289NQ+nazQBSAEKObfAurGVKZh94HbFz8wqXrJfILmK4BCljHb6tZVmAL8r5G
-        aOOz8X5XCh54WBaP3I13zsTrBABf/Ic4tliqC/tiRCD5xWXrDxVgzUOv/q0/2PPHT/UVX30LrYPB
-        IRMpYjVJyb7+9aPI+VWJYHolvQIf6+avN36xoGZqRVWvEYlj+h6WRbStH2/ErZvV8dJPUQj53fdM
-        3Ls9q1uexRCZtUuKTQ8XyWfvYC964Jdv09EalRIK2qcMxHkSASbTzjn8+hHOpv9zUEvR8VQlcsCE
-        8ytl45JYUCqWL0GMKoF9VBx4sXOmhaibv1wb5rNCV7iWwQDe54Hu3U8Eg+bZY/FxM6r5VX08eKru
-        MkkcPNLt/s0whLqPAi5zKorsrAa7iCXIA4uest/sZPx4KD5w0pquGQ69Xz0n58TWwKS9GgNYlVBt
-        /uxKFyop7VHR2Svyx8ekrqGhjDBrOm3r99R0pPeh+/kpXJtwjRfzgwt4CW410bTUiRfuYGE41qaI
-        mYCp6dgehBaslvoNarRTKN/2/QyZ1/lBUCgrFe8PoXO0J44h/qF5pivSry38Vm+AaUzf1WS59A38
-        8z0n2ejAeHGcAILvETyR48nLMBnR8QzoNxaCyc7IsAZCehaTqxMRWbExmNX7iYfycrwT7XzrqhFe
-        +1UkQZsiZxn6eN4teQR8ejwj50U8l5NX+X7ceDzySVOqGy9PoIeKEx7kj1Xtw0IfoSOWBgmElzvM
-        SFgScLLSE/59//WlWAzc8mGw++NvVFUAunVmkarexx+vDqHvRwPSpP1SrXUGCvBODRuZN31wV2be
-        BeAxvR3iqYYfLzWXvcHH7mqSk/QYTyWjCFDIuxkZsFIpf4n0QkQOyyCT2wnuzHIKhmO53/JyPFAc
-        l8fg5/dRrh1vYD1WUAIxUVjkmN8BzBe9OwNbsQz89tfLsPXjIlijxkXWcX0N3Td7aD9ehMXnkQzz
-        1j8CEuswQXG79jF9q3jbv90ZGdp4H1Y956zjr9/t2jIzDDczHSHXvPdbfksqekN2Bx3xbSBvFbf6
-        S4UC/vjMHLEunZ0+h2C7T3/0g9blkgHERJRIj4MH+vu4ZyD3Ka7IUa6feG53Ovvz7+hXb/AYe1s+
-        1idi1Hoe490bZUA20wWvejK7S8tbHQxMNkKK6Xnpcl3PBSwzMOCN19JJ568BrKksY/H8uLm9t8st
-        0AyDhbSSYHU8Sr4Bb/7+SjTmeo1x77sh2PwwCZjYBHh+iA786zcV8O9//POf//ObMGi7vGi2wYCp
-        WKa//29U4O8kT/5mWf7PGAIek7L461//nUD46zt07Xf636mri8/417/+KfwZNfhr6qak+X8//2P7
-        o3//4z8AAAD//wMAa/I8J94gAAA=
+        H4sIAAAAAAAAA1RZSROyvJbe969469vSVSIgCXfHPJugOGCvABFlEBkSIPfPd+nb1V29sSqEhTmc
+        PNP593/8+fNPl1VFPv3zrz//NK9x+uc/v8/u6ZT+868///Uff/78+fPv3+//e7Nos+J+f73L3+u/
+        zdf7Xiz//OsP/79P/u+lf/35Z1tkFmoSgGLCe2cBlq/Ro5n2dof5MXkjwIW1UCPvVWOUm+ML7INr
+        SE02wYqdFy4Bn+joUl+8t8N8540SbrylINysrIyhxnnB9+DK2D7q+2qxXwcEt058IkOR1gbztwMP
+        tHjaUn0fK2CERTKCdDoaFB0Ni4nqR0kheJkEo87eDmO32XGgb59vGu4jHM83uJNhkdsNAokXBcxX
+        bjNcPcWlYawP1dSSdARG49kIKKcloEZ4l6FpnVzs3rMpnn7/R3CMPVkK2MfzrUx5eNufXWqKh3O2
+        6CHmwas85lSPEg60gq9xCse/Q4x7iWPrHWQp7BryxOoJKDER9FyHQK0TvL+J1jBH+74Gh93ujY29
+        cWGrcwEXSG7Ywd6afow5WANJJmLRky1n02yqAjmC69pEaGyNHrB0fzeBc9clZA21A1hyKiRY2FJM
+        L/RzBqxz3yGUX5ct3m+EOJ4+EUDgqccqNh/gGbAPTGxYJVJFrSZmbJqbRIVnQRlx4O4XwLB3quEk
+        KzVS9g/VEM+eG+0u2+RAz+x+HpZT1PlgP49P6h9Ol2A+ZjcZmplIkFAdoozxH7TKhx14471sikZH
+        ukyAolHG2JGoGXQumwtFTI0dITvVyJj2Aq18m2cOI9YT4/MIZQKB2ibY/LRDzHbmlIMJAoNqb+ZU
+        tA7dE4jNLqL3WzIBlu0iHVq7rU8xj3hjPp0iG2wW+0h2vRDFffEoCyWhToOdzXkfLJYlu9Cu04U6
+        T2KCZWyTXB4eAcHh63E05rNVXkAt4ZgsqtDH6yTeOgBu2p36p9vVWNdk3wIcGQckHta2YpkdR5B9
+        ZAPxVymq1kc0j8pRKQsiS/MQL8jYRQDU+p7q4JwbYzVqR+icgYOW7s0PTIldCcbK8Yo9238ba783
+        ImjrUkZdJf6A9TPXPiSmukUSPgSZeLkEObzQhlFcsTtbd3xyAgJ3UbE2ybdgLteCg4YNKhoajWWs
+        ZS+aoPPpgl1JteJ5SaNwl3HnCGsewmC+Ur8Gh3tT0YBc9Hgh44FXZu3tYj/Y19VScrq8KcnW/9b/
+        XS16deug4HIjAtXkVkwmeASvMspx9Doc43q5bkqIPpeOouRDjdm8v214X0aNGtfPBkwfQ9IhlZ4i
+        WrP7Y2C7MEvB7D8uCMLmmP3t54OBNlR7ZK9g2XV1Ap3W9HBwubJqXNIEwRuvLTRUKo3xsEgIAOF0
+        w15TDWwMq9wF++Ac4st6e7I1Wg4lgOHjiDphUqslBA8X9nLaUDdxO7Bke+ZCJiCHqnxhsjVv+wh8
+        Dk2O5AObwLReugi8j06PxPeliNfl4aRy5ioQ2+LYxstHe1x2fVu9kRxunsYcZm0IPxuBI+HkDoy4
+        Eu3kKUsnbPAqn/XNMtbgYPkFDcHSxKwudwX0CdIxhu1tGBefv0AcaQfq5JmaLWxue/jDGyTpjBHJ
+        vScw464RRi66BWM8BzroXRljvRireH2vyQgVOqgECHgOZhZ0+W9NTW3gstXFu7/4i5QdfRnjJT3k
+        CgjpDe3UxAdMDOgRbnvqYXslAqM7syngpGYceQVDbSzUnTmocnDAYZYejC6B+xnIusdIl7zLar2Q
+        uvx7/mGGQbV9hPIIw+Ad0+/3AZPXpTUAuZTR6CDk8TrRaoQ553jUhWc57noLJLAWYh678JxmC38C
+        I8wX6FL/eLSqdXngBJyvyRYxeS6NOfW2PlSSCiNY3Z/DfBbCBHBn/Yx/fERuyQrl89g4RJrzsfri
+        vQQKzRJ+/DOsr9w5AQX5PdYzKGbjVr5CsDnNiGQCeYOOzNoMo05IqX+VN0HP3p8cDh3aIHEe2UAA
+        usyQvKKE+uIKhhmFXA5l8enQMH4a2bj50AtoTtWVukzhh7Xh6ApbTxpw2L9e1bqQ6ggje9ohyXvg
+        YHYc5QV3OzJR880TtkzXbgTSjuPpDw8py40WcknsUtUZ04xcjTMBdysEWKUuHtjVyQjUTheVNFn3
+        GdbDXurAWdiMRLm2h4wieDvBx3VTYtMjCJA10BMQg4uEA3xch3mKXwTaqR5iq4ljNj+LGwdN6+IS
+        dv1s2GeRPR8+NlFMBH4zBP3h9Zzh00QPbIS4N5ZWUDt41lGF3bPID4t67i8w5HH29z5/8H3Tw5Oi
+        R2inGC+2IGhE8FOcOlRa3hN89tQ14TtaL9iN6tmY9bEQ5IuqK1RPMpqxeTeY4IU8GfFFcWPMtl0E
+        2/l9IqKXagZD7zJUZJBY2CetF/Oki3koZpuE7qndZWxj3lx4fEQAa5KZGUu/VREk17gjb8cLGRlj
+        s4emAjF+GM6pWtyEI4B3nhlW+4/ImLB0AmyOjUS2KtxUC0r6BNp2gIggL+94HI5cDbnYFKiRB102
+        ldYsy4JlEaq39i2eveWxwiZJztiwHkUwm5MPIRoiBx+3qGezgksIV1f7IFA+t8M4mTYP9u9PRJ1T
+        QsF4oBcZbhcBoK0bVNnH4kIfVsTc0v3V2VXMC7VW6XqZIeEGsphyb1kHpZm3NCjoLpjU11TKX71D
+        /baSwGwh8SS3n8cL7fSWxPR0t45QlplMLftmgxkOmQyMzbMnP3x7eKFWwz7FFZJKTRjY5nA6wXzh
+        XCL7eGvM3Xwxf/qNvLbTa5hb8SpBjqY7jANuAfS+uaVwTsgObQ96WTVFN/Vgv5UZNbhWicfTQUzh
+        l38QTxOnorJ1aOX7QjS0iV9+tSbvfpTFTEnIK64XNp8OmwTmD7FFSqhLbEQhV8iKsK4/Pst++k9J
+        juyF2nTns6nfuiHcF82GmhK2guX1nhAMP4JATVwOAWv9eIWeADChshrFkxt/Cng2XR277aLHK87L
+        BNJUfiBhOJXgd59BLycNNqBhgmXwlgSK9mITqSxRPAMEeRgO6xl1o8QYHfFphMI7xBSz1AlYcJMk
+        4F7rB93nsK1mqSaJ/OZuE3ZRnLHZvR5SeHcfBKMiC2J2XV8v2DqbEMFYDyr65CIOJiusiZznTrWI
+        G90Eypjs/6cfEF+lgI/FB/U7fjKWQb7n8u1NJyK3VQLYbLcXmEac+leP0qucFPB5fjJqj+9mWN4R
+        toGpcJiqIXqBZaNoCFJjJRQJkZjNRjTIcH6uPpHTPggWurvr4H2GHbVHdw/4g92tcMu1DpEOxpst
+        j1PZgZ/++eLxQJttX4Ovv0CLZGbBcnSRDefLkuJQMf1gkcxrAj1SeGiXSc+B9gctgkvoE6qeLdXg
+        DbCO4FsPbNTV9PUXuJSPr4qiTU4U41tvstuyNSWZVNbZYlmrvzsoa0MUPBnDKhmqDwLpVFKdj7Ks
+        8xt1hHadLNgOoyVe9tS14Rmda3T4NKax1bOBQJeQCLskkOJO1FcTVGejQWulSfH6KkpVccAxQ5fh
+        pILtIms+KBsOUqzuFmPMtpIJtWY4IcXsXqABQkzAxtluqMXgPmPp2dBlsL0+CW/KL+O3BkcbD0Q8
+        xARMR30W/tZfR4d9vKzDLQXL82VQHc1NwOSt0oNtx3pC1fSWzVUdX5QldAm9nT5cQIzHkwB3i0Wy
+        48OmYr0XX0Cb+AiV9asdZuY5K5Ts14aQ97EbZrM568ANG0q2VibGizHnPDw8Kh2H8qkwmHaWEgiv
+        uY6eSIfDe12fRzjtughb5NOByeJM/8ffWB+FJma7k3eCt/c0URtWFVtp95HkTxS51HTnR/ZXD8Rm
+        H1FHonWwXDNuhRzGInkl8tugjZKUIDtqe7T2zSFg3zXkkoOLdWv3/h++vE2lj1PH54NZvo819Fly
+        xmEsJPF3n8Dl8oyJrIl4WBOY8b9+R+yp1NVqeqEKJzKURNAbJ1g/1v0kg5txx9ocTNk0Fq8S1MzQ
+        0GYFNCMX4ZiD3uZmqprBMfvMyEaQUfuMNpVSDgveegV0zjsH63CtBpbmM6d8+ZGG1ihUDX9io6Ke
+        Wodsp4sZL2YIIOQCxUQCX7K4u1/rHFqWrdHAgvdh1N9arfBbqGITl0HAosIiMOhNhXxgPRjUJsIF
+        dqNwpMbeEEDPH4IZit0hR2KeldkiW0EJHGPTUe1jjzHrXIrk9IQYxVbSgTkrSAQW7apRo+efjGnI
+        L+ALzRaOHuESr5HQrvC7T0BXtwaZj2Eo8+/xTu27mmeD2UEIr8K9IDInwqER0q0JwzWGZHp8noDp
+        jtpDdXAmwlWEsmVxwhQ+ZFPDxnHLAvqYnx18ZaaHIn/J4rXeX1to5ESldhgd4mkdDql8O4QOPnFb
+        ZJAreI9y36CYBl55yeYwIwiyYhfT+9W5Df1ChiMQfCmgheYlwfKOHBvgcL5jy761bI5FCcLpVT6o
+        +q4vbCH1IEHeaiDFg0AyWh4LFbJQ4XGYgl3G1vUTwTQ6b4n09Q+/vELuI1WjzhIE2VzbePz1Jzav
+        psHWtn+t8FzmNt6noVyxiudymBXrDev7uzowfNBfMD8sNk460wl+fla2wPoh8jM6ZWv/hAmE06Yj
+        Yvh4BbN1iFR4utUZvRlWG9Dg6HPgUNMz4bvYZjNRQg7eXF+glpWJ2ST0CQfVU+0gtux0Nt86d4Vm
+        tiVkzd6veBE3vgk7L70TaRKMrGvOVQtdPd1T35vv2SoWwP6dlwbjLgsmrzvWyqDcDti89ftgvQjH
+        ApYbNUQikcWAFdn8UtzwTckkLetA+GQ3yl//jJ1LG2fT+7pVoQj9FAnGLWbdVrc4OJ8Lm1rNOlQz
+        kI0efPkSa9HaVVNOaQHvVV4Q8a194m65iiWUdpCnYVAcGduevRV4wg5TR4rCbNls4+OPP0jxzYvm
+        z2lwYawuR+qY4JON3/rJ++K9IbJ0YBX9PBYd1h9lxurz3gzL0bVNaEJ9ps5hbQd6XrgUlC/i0b0m
+        CYyqu9sRzkuwQZtv3sCua1/KV208Y+9iN9mEt1q+a/dBQeZNZVXzy+Ej2aPLnbrTNagm9Z5E4Hy7
+        nOieyttg/dYHxCU80SPptGHu5sIGnJT7OL5+Hmy+P9IU3osooOGL+wA2NHIqakwSv36+yb785cIB
+        PFayvVNgTKWQQ3hNBJuG1V2rxr3zCeGv/t7Z3QKKRiWHP30xrlmUrQ47JvAiDSbW5k1qMBK5PMRW
+        N+Lgm5/13zwDJMflhd3EdcECOK8Ha+/65M0J23h6iZoJRrMyEEW4DZaPdr1AigGl3qYFGTOy3Qqu
+        ARAp0p33sPz6Ec8oxqHd28ES6SEB5LZ3kIRnwxCrcn/6m79sjnUWrCTUeXisHwjNG0kepv1jRHCs
+        RwvfFrDEU/k5zIq2bBLEeaE7zEPvplA7pk8ilof7sPq7eIb6Jwowut8B67zdnvz8LALbzIi3crjk
+        8g8P9Kk/Ggtz5lJxVLJFeSwkGWO5UUN+9iqsjnJoUI7fIoAc4Uge26dU/cUTn6cfjA41CRZ833Tg
+        y4f0cGjP2acx5xxSMayom9zvYA3XGwe46Z5iY/8iA3VL1MIB3NefHmNLvro+MO9sj7Fq1fFPz4MX
+        uUC07PR+IIfXZ4WRczLp41iDYPbcTwdcoJ6IUFv3bOESiP7mR452jQYmUT7a1UmXE/lRiGxR9zCB
+        lzieSc2mvGL0fLHhU+xOWLcRBFPoMxP0m1b84U+8XDQpBXOYbNEaGR5YqaWp8tePkuGBZsBuFvV/
+        eRMRvnkIcV2jBXyQ3OiX/9mw3ceCzHuFjL73NxvRqU5/eEE29/0JrMFLsOHophrp6W4C5IvXsDm+
+        JQIi+zFMbVvP8F6zlWJLLCsmwU0hvy3WYsvKrjH75rcAvz0d2zt2ZfOjyVZA7rZF0SWRwad7vCBo
+        1xejQWQ/qhk4SAbf/Im6Q4ODhQsWVbFe9EbR7LVBuyb7GrR8fqTHuD6AeVYWG7pqTqijShJbqCtx
+        8OuXqfv1Pytoyhaka35B0tffL/eYL+H3e+CHe/+Az9xPR/h4WAfqZTcP7D6GpMImRga2gnHIvnrX
+        hFoQUbwXSi7+1RdAUd+R1QnHeI7OUQl3LrrSXz4007CU4bAcI7TbYzeY3TpvgWQcQxyUoVrxt6lQ
+        4efwzrHPvd7DzIy1hHHmCQRIWlgx6/O0oXGQY8J98ZFXcMfBVcgR3Z/qZ7A0B9D/8htsy0dc/cWD
+        yLmYJD93JzaL1wop76A1qO5yHVvGC6zhduEBDjR3ZitouvYv/qhpYg7LLe+lH95jO02Zsdb1M4XZ
+        YN6xp7cko5fK7kBN1z0Nsl4yfvMD+GmKlCSXbW2w0/hxJeNtN2R+zb3xzM4fG56v6ZbwT2QxuvTs
+        9Ddf9G/Xtprqqa3heG9jchc2F2OWHgcfWjvRp75PQjC34kOG2GkDtFblbEz+M1qVJT6W2OuvyfD1
+        RwXMe/5C/e99YcdiEcRSbTrERqcdFtBueOksCz1SPPCO2ZQ/ZJgOp5pGGymtFiadWpidpYCal2YM
+        vudJd788w3TcpmKnmoUw9QRE1Vt6DpZn+lJBOkUGNp+oAXOOhRJ2q9rgPFD6Ycy2swlZ0JdoM3nM
+        YFa6Rz8+pyfdF4yRG10VepTdsV5pSbw+tJz/4TvZtXo1zBd/WwMx1XZUq+arId7UmwwO6WmmBQsu
+        8QDflgT2n5pS7/gah7/zlXo/jCQ+2068WnfFBXtu0fA9fM4VCfpRBXE2a+j91rx4iQ5dDaySydTz
+        OQaWjj/ZcKjUCUdypAX8+mhyKD9sDT3njRwwmwgn+NXPZJPZRnYLfWDK0QYG1NXaZzZvlnMEx439
+        odY3X5mb/bYDXaecqJP6Y7CmDedDqm0xRSpvBAt3sCPAe7mMg3b1Bn4H5lAZnhbC1pZ4QBCvexde
+        R3OHPWO3ApKTBCmWQtxv/zSMvYIcyRKQYnzVrlE1Q6YJMHyDby5+3mbr+bgvYLYijHh/31azpsMW
+        3Psa428+G4ubUgrBzXUFHHzzzpmGnQTgU3hT35NLY+GfnAzUfXH+zocKsN6jsP6dH4mC8q4+8rNv
+        obuzt9jBulxNairWv3kUPT0rGUzPtNfhbf3q629+seBmamXDqjGNY/YalkX23F/eSNogr+Oln44R
+        FDafEw0Sbza+fpZA7NQBLb54uKh7PgGiHIKfv81Gd9RLKJnvEsnzJANCp42/+80j/C/+z6hWj8qh
+        SjXERfMz4+OSulAtlg/FnKEC8VjsBLnzp4UaX325Ntx7hYF0KdEAXqeBicH7CFHz6Il8u9rV/Kze
+        ITxUiUZTn4zse/9mGEFrj9E29yuGvbwGmyNPcQgWK+M/+cH+5aFkt1XXbM1JFP74nJ5SzwST+Wxs
+        4FZS9dVnF7YwVW8V3eIveD/eJmONbH2EedOZ33lPzUaWDN1PT5HagWu8OG9SwDO61tQ0Mz9etjuX
+        wLF2ZMIhrmZju5NasLrGB9V4ozOh7fsZcs/TjeJI06v/BgAA//9MmklvozAYhu/9FVWuqIIkFJve
+        QgibWZwAJYk0GkGgFLKQGGwWqf99BBmN5uqLJVv29y7PwiVbJFvNnGPu++Ur6bEWXeG9LAAdgqEo
+        G9MeCuCGh5SdagSDDiEPgrsMvjBylI40ui+HYLgHotdYJ0Z6T0xCKY6Qz5S1RUGrHnYLqHTygW3C
+        fVXWMHr0EvOuCUYdeQQt36U+cAc5xOibOfZc6ZWDPObx2GWXXB3z8hg6ONtRotzMcrnNtBoiKdeZ
+        J37bpMViF4OdmezodP/999rk4OgPPf6pb1RVBJoZClhVD/WUV2+h6/oEb1bLruzPJ5CBItEtbOw1
+        Yvdcy3vg2BSIOaruBt15firAzarOLGWJHDQ5txahmFYt1mGpDotPX8skjAQOG3NetFthvqawzpej
+        Xw7IQINc9ia9j9ONvAe9XMIVCNhawMi4E9B+alUIrLWp08LtP8nYx/nwjC82NuX+m1T303Ez5UVU
+        +pIZacf+CKwExHnZPnoEQ6HS8fz4EOub+kB6LZ2b8tR325bCEbI3khrOL8Vy9G9xOeyxVUEkFTp2
+        emmcv4OYwSmfaX3BHlr0SCEY39Pz/xjOeXcCmPMHtjq+O+BxqJccnN+yCKN1dAvaK68Jk37H07yh
+        deCM/lhrmH7W0oDyBT4BxUg62mtxa3fXhVlBzxB8vDYcJ+miPsxgfgKEjnnt0GiLyIPnQVGoFB73
+        9sPhUxNcCDHxJmdUreWVq8O9u4zYhouigD5cewtGPcw8LjAAbY8SgrOJCvh5eX39NREG1yrNLiMY
+        0GRd8/YPFXiL0/hNEBZPDIHWcZ7NPv4SCLM7qa735ndTnbNbPft4FZ+owaypmvjy3/LLuNHPyx8A
+        AAD//wMAa/I8J94gAAA=
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87991e40b9c745e8-DFW
+      - 87a1eb1d5e37eafa-DFW
       Connection:
       - keep-alive
       Content-Encoding:
@@ -142,14 +142,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Apr 2024 21:17:06 GMT
+      - Thu, 25 Apr 2024 22:55:03 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=6E1pWLwbvDQpV2yiEjsiu9DDLDXAAwJZU.0BW0PVCpA-1713993426-1.0.1.1-T51_bXq9sB7T8ZUir1QmUfrZQSyKNMqZZOiKm99uU_SVO394.trnP7meoksiUFDv208PHB9XAnMf83B0xLXdSg;
-        path=/; expires=Wed, 24-Apr-24 21:47:06 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=j41NI3LVWFxjNiqN3DBXl0f19r1AsfX2OdmYe7myEI0-1714085703-1.0.1.1-XWVhwkqScp5jTWtfyh9vjQZfSBMMDRjrAvVgFEh3UTzdU15N6nHNjoklyncUiKRuvlSlZMCyMo2qIxswrzVI8w;
+        path=/; expires=Thu, 25-Apr-24 23:25:03 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=PyJnU_suSG_2m1j4wJyIFn3GR83oTJApRrnlgnQ8Bgw-1713993426084-0.0.1.1-604800000;
+      - _cfuvid=rJSflBXxcLbXE6VA3g0ZWR4VqjhYThnXMwf06fKEVsY-1714085703371-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -162,7 +162,7 @@ interactions:
       openai-organization:
       - university-of-texas-at-austin-8nppuy
       openai-processing-ms:
-      - '21'
+      - '42'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -174,13 +174,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '9999'
       x-ratelimit-remaining-tokens:
-      - '4999996'
+      - '4999997'
       x-ratelimit-reset-requests:
       - 6ms
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_9e3f8b77ee133867a78ddc841715829f
+      - req_c8270afbe8289949f30528d74925127e
     status:
       code: 200
       message: OK

--- a/publang/utils/oai.py
+++ b/publang/utils/oai.py
@@ -130,7 +130,7 @@ def get_openai_embedding(
     try:
         resp = reexecutor(client.embeddings.create, input=input, model=model)
     except Exception as e:
-        if os.getenv("PUBLANG_WARN_ON_FAILURE", False):
+        if os.getenv("PUBLANG_WARN_ON_FAILURE", 'False') == 'True':
             warnings.warn(f"OpenAI API call failed with error: {e}")
             return None
         else:

--- a/publang/utils/oai.py
+++ b/publang/utils/oai.py
@@ -76,8 +76,8 @@ def get_openai_chatcompletion(
     client: openai.OpenAI = None,
     output_schema: Dict[str, object] = None,
     model: str = "gpt-4-0125-preview",
-    temperature: float = 0,
-    timeout: int = 30,
+    temperature: float = 0.01,
+    timeout: int = 60,
     response_format: str = None,
     **kwargs
 ) -> str:

--- a/publang/utils/parallelize.py
+++ b/publang/utils/parallelize.py
@@ -30,7 +30,6 @@ def parallelize_inputs(func):
             results = [
                 func(i, *args, **kwargs) for i in tqdm.tqdm(inputs)
             ]
-            results = []
         return results
 
     return wrapper

--- a/publang/utils/parallelize.py
+++ b/publang/utils/parallelize.py
@@ -22,7 +22,8 @@ def parallelize_inputs(func):
                     exc.submit(func, i, *args, **kwargs) for i in inputs
                 ]
                 results = [
-                    r.result() for r in concurrent.futures.as_completed(futures)
+                    r.result() for r in tqdm.tqdm(
+                        concurrent.futures.as_completed(futures), total=len(futures))
                 ]
 
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,5 @@ install_requires =
     numpy
     scikit-learn
     tenacity
+    untruncate-json
 python_requires = >=3.7


### PR DESCRIPTION
- ENH:  If after `PL_RETRY_ATTEMPTS` (default 10), the API service doesn't return a result, the file is skipped and not added to results.
- `PL_RAISE_EXCEPTIONS` determines if an exception is raised, or just logged and article skipped
- FIX: For the `search_extract` pipeline, results are now saved sequentially, to ensure every result is saved, including older ones (when restarting from file)
