### PR TITLE
FIX: Section header assumptions

### DIFF
--- a/publang/pipelines.py
+++ b/publang/pipelines.py
@@ -119,7 +119,7 @@ def search_extract(
         if embeds_path is not None:
             embeddings.to_parquet(embeds_path, index=False)
 
-    if section is not None:
+    if section is not None and 'section_0' in embeddings.columns:
         embeddings = embeddings[embeddings.section_0 == section]
 
     # Search for query in chunks

--- a/publang/search/embed.py
+++ b/publang/search/embed.py
@@ -31,7 +31,6 @@ def embed_pmc_articles(
         List[Dict[str, any]]: A list of dicts containing the embedded articles.
 
     """
-
     def _split_embed(article, model, min_chars, max_chars):
         split_doc = split_pmc_document(
             article['text'], min_chars=min_chars, max_chars=max_chars

--- a/publang/utils/split.py
+++ b/publang/utils/split.py
@@ -130,7 +130,7 @@ def split_pmc_document(
 
     # If failed to split, markdown is not formatted properly
     # Skip for now
-    if len(re.split(f"\n# ", text)) == 1:
+    if len(re.split(f"\n## ", text)) == 1:
         warnings.warn("Skipping document, not in markdown")
         return
 


### PR DESCRIPTION
No longer assumes `section_0` exists (good for Abstracts)